### PR TITLE
removed double quote from $v_mailer_app path

### DIFF
--- a/resources/switch.php
+++ b/resources/switch.php
@@ -1303,7 +1303,6 @@ if (!function_exists('switch_conf_xml')) {
 			else {
 				if (file_exists(PHP_BINDIR.'/php')) { define("PHP_BIN", "php"); }
 				$v_mailer_app = PHP_BINDIR."/".PHP_BIN." ".$_SERVER["DOCUMENT_ROOT"].PROJECT_PATH."/secure/v_mailto.php";
-				$v_mailer_app = sprintf('"%s"', $v_mailer_app);
 				$v_mailer_app_args = "-t";
 			}
 


### PR DESCRIPTION
if this is left in freeswitch (1.6.20) will not start up. 
Freeswitch: Cannot Initialize [[error near line 4105]: missing >]
there might still be a problem on line 1299 -> please correct me if I'm wrong.